### PR TITLE
Improvements for Importing Resources

### DIFF
--- a/bitbucket/resource_project.go
+++ b/bitbucket/resource_project.go
@@ -26,6 +26,9 @@ func resourceProject() *schema.Resource {
 		Update: resourceProjectUpdate,
 		Read:   resourceProjectRead,
 		Delete: resourceProjectDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"key": {

--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -297,7 +297,8 @@ func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 			d.Get("owner").(string),
 			repoSlug))
 
-		if err != nil {
+		// pipelines_config returns 404 if they've never been enabled for the project
+		if err != nil && pipelinesConfigReq.StatusCode != 404{
 			return err
 		}
 
@@ -315,8 +316,9 @@ func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 			}
 
 			d.Set("pipelines_enabled", pipelinesConfig.Enabled)
+		} else if pipelinesConfigReq.StatusCode == 404 {
+			d.Set("pipelines_enabled", false)
 		}
-
 	}
 
 	return nil

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -31,3 +31,11 @@ The following arguments are supported:
 * `key` - (Required) The key used for this project
 * `description` - (Optional) The description of the project
 * `is_private` - (Optional) If you want to keep the project private - defaults to true
+
+## Import
+
+Repositories can be imported using their `owner/key` ID, e.g.
+
+```
+$ terraform import bitbucket_project.my_project my-account/project_key
+```


### PR DESCRIPTION
Some small improvements for importing existing resources. 

This PR adds the default importer to `bitbucket_project`, as `resourceProjectRead` is able to initialise the resource from it's ID alone (c.f. https://www.terraform.io/docs/extend/resources/import.html#importer-state-function).

We also fix a small issue with `resourceRepositoryRead`, causing it to fail if pipelines have never been enabled. In this case the Bitbucket API returns 404. This fixes an[ old outstanding issue](https://github.com/hashicorp/terraform-provider-bitbucket/issues/58) with this provider