### PR TITLE
Add forked repositories

### DIFF
--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -240,10 +240,10 @@ func resourceRepositoryCreate(d *schema.ResourceData, m interface{}) error {
 	var temp interface{}
 	var parentMap map[string]interface{}
 	var parentIsSet bool
-	temp, parentIsSet = d.GetOk("Parent")
-	parentMap = temp.(map[string]interface{})
+	temp, parentIsSet = d.GetOk("parent")
 	if parentIsSet {
 		// TODO: Validate the parent
+		parentMap = temp.(map[string]interface{})
 		createRepoEndpoint = fmt.Sprintf(
 			"2.0/repositories/%s/%s/forks",
 			parentMap["owner"].(string),
@@ -339,13 +339,9 @@ func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 		if repo.Parent != nil {
 			var parentMap = make(map[string]string)
 			parentMap["owner"] = repo.Parent.Owner
-<<<<<<< HEAD
 			parentMap["slug"] = repo.Parent.Slug
 			d.Set("parent", parentMap)
-=======
-			parentMap["slug"] = repo.Slug
-			d.Set("Parent", parentMap)
->>>>>>> e6099d2eec3c70f14227ed9a98ba5f3f1012a05e
+
 		}
 
 		for _, cloneURL := range repo.Links.Clone {

--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -48,7 +48,7 @@ type parent struct {
 	Slug  string
 }
 
-func (p *Parent) UnmarshalJSON(data []byte) error {
+func (p *parent) UnmarshalJSON(data []byte) error {
 	var v map[string]interface{}
 	if err := json.Unmarshal(data, &v); err != nil {
 		return err

--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -43,9 +43,9 @@ type RepositoryRequest struct {
 	} `json:"links,omitempty"`
 }
 
-type Parent struct {
-	ParentOwner string
-	ParentSlug  string
+type parent struct {
+	Owner string
+	Slug  string
 }
 
 func (p *Parent) UnmarshalJSON(data []byte) error {
@@ -54,16 +54,16 @@ func (p *Parent) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	p.ParentSlug = v["name"].(string)
 	var fullName string
 	fullName = v["full_name"].(string)
-	p.ParentOwner = strings.Split(fullName, "/")[0]
+	p.Owner = strings.Split(fullName, "/")[0]
+	p.Slug = strings.Split(fullName, "/")[1]
 	return nil
 }
 
 type RepositoryResponse struct {
 	RepositoryRequest
-	Parent `json:"parent",omitempty"`
+	Parent *parent `json:"parent",omitempty"`
 }
 
 func resourceRepository() *schema.Resource {
@@ -336,10 +336,10 @@ func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("description", repo.Description)
 		d.Set("project_key", repo.Project.Key)
 
-		if repo.ParentOwner != "" {
+		if repo.Parent != nil {
 			var parentMap = make(map[string]string)
-			parentMap["owner"] = repo.ParentOwner
-			parentMap["slug"] = repo.ParentSlug
+			parentMap["owner"] = repo.Parent.Owner
+			parentMap["slug"] = repo.Slug
 			d.Set("Parent", parentMap)
 		}
 

--- a/bitbucket/resource_repository.go
+++ b/bitbucket/resource_repository.go
@@ -43,9 +43,9 @@ type RepositoryRequest struct {
 	} `json:"links,omitempty"`
 }
 
-type Parent struct {
-	ParentOwner string
-	ParentSlug  string
+type parent struct {
+	Owner string
+	Slug  string
 }
 
 func (p *Parent) UnmarshalJSON(data []byte) error {
@@ -54,16 +54,16 @@ func (p *Parent) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	p.ParentSlug = v["name"].(string)
 	var fullName string
 	fullName = v["full_name"].(string)
-	p.ParentOwner = strings.Split(fullName, "/")[0]
+	p.Owner = strings.Split(fullName, "/")[0]
+	p.Slug = strings.Split(fullName, "/")[1]
 	return nil
 }
 
 type RepositoryResponse struct {
 	RepositoryRequest
-	Parent `json:"parent",omitempty"`
+	Parent *parent `json:"parent",omitempty"`
 }
 
 func resourceRepository() *schema.Resource {
@@ -336,11 +336,11 @@ func resourceRepositoryRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("description", repo.Description)
 		d.Set("project_key", repo.Project.Key)
 
-		if repo.ParentOwner != "" {
+		if repo.Parent != nil {
 			var parentMap = make(map[string]string)
-			parentMap["owner"] = repo.ParentOwner
-			parentMap["slug"] = repo.ParentSlug
-			d.Set("Parent", parentMap)
+			parentMap["owner"] = repo.Parent.Owner
+			parentMap["slug"] = repo.Parent.Slug
+			d.Set("parent", parentMap)
 		}
 
 		for _, cloneURL := range repo.Links.Clone {

--- a/bitbucket/resource_repository_test.go
+++ b/bitbucket/resource_repository_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccBitbucketRepository_basic(t *testing.T) {
-	var repo Repository
+	var repo RepositoryResponse
 
 	testUser := os.Getenv("BITBUCKET_USERNAME")
 	testAccBitbucketRepositoryConfig := fmt.Sprintf(`
@@ -36,7 +36,7 @@ func TestAccBitbucketRepository_basic(t *testing.T) {
 }
 
 func TestAccBitbucketRepository_camelcase(t *testing.T) {
-	var repo Repository
+	var repo RepositoryResponse
 
 	testUser := os.Getenv("BITBUCKET_USERNAME")
 	testAccBitbucketRepositoryConfig := fmt.Sprintf(`
@@ -78,7 +78,7 @@ func testAccCheckBitbucketRepositoryDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckBitbucketRepositoryExists(n string, repository *Repository) resource.TestCheckFunc {
+func testAccCheckBitbucketRepositoryExists(n string, repository *RepositoryResponse) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/docs/resources/repository.md
+++ b/docs/resources/repository.md
@@ -56,6 +56,8 @@ The following arguments are supported:
   allow_forks.
 * `description` - (Optional) What the description of the repo is.
 * `pipelines_enabled` - (Optional) Turn on to enable pipelines support
+* `parent` - (Optional) Specify a respository to fork from. Expects
+a map with two keys, the owner and slug of the repository to fork.
 
 ## Computed Arguments
 


### PR DESCRIPTION
This PR adds the ability to create new repositories as a fork of an existing one, by specifying their owner workspace and slug. Forked repositories can also be imported.

The one complication is the need to add a retry block because it seems to take Bitbucket a while to set the permissions properly on the new repository.

Apologies for the slightly messed up commit structure. I'd recommend squashing this one on merge!